### PR TITLE
11-git-setup

### DIFF
--- a/docs/HowTos/GitAndGitHub/git_setup.md
+++ b/docs/HowTos/GitAndGitHub/git_setup.md
@@ -1,6 +1,7 @@
 # Git setup
 
-Make sure you set up git on every machine (including servers such as HPCs for example) you work on.
+Git has many configuration options. This section covers some of the basic options that are recommended. 
+Make sure you set these configuration options on every machine you routinely use, including remote servers such as HPCs.
 
 ## Configure name and email
 
@@ -10,7 +11,7 @@ All commits on git have information about the author with the name and email add
 
 When working collaboratively with git, you will need to synchronise your work between your local work area and a remote repository. To remove the need to manually set up the remote connection for each branch, you can set this configuration option:
 
-```
+```bash
 $ git config --global --add push.autoSetupRemote true
 ```
 

--- a/docs/HowTos/GitAndGitHub/git_setup.md
+++ b/docs/HowTos/GitAndGitHub/git_setup.md
@@ -1,0 +1,20 @@
+# Git setup
+
+Make sure you set up git on every machine (including servers such as HPCs for example) you work on.
+
+## Config name and email
+
+All commits on git have information about the author with the name and email address. Before any work with Git, you should configure them globally for each machine you use by typing in a terminal:
+
+```
+$ git config --global user.email "YOUR_EMAIL"
+$ git config --global user.name "YOUR_NAME"
+```
+
+## Config auto-remote
+
+When working collaboratively with git, you will need to synchronise your work between your local work area and a remote repository. To remove the need to manually set up the remote connection for each branch, you can set this configuration option:
+
+```
+$ git config --global --add push.autoSetupRemote true
+```

--- a/docs/HowTos/GitAndGitHub/git_setup.md
+++ b/docs/HowTos/GitAndGitHub/git_setup.md
@@ -2,11 +2,11 @@
 
 Make sure you set up git on every machine (including servers such as HPCs for example) you work on.
 
-## Config name and email
+## Configure name and email
 
 All commits on git have information about the author with the name and email address. Before any work with Git, you should configure them globally for each machine you use. See [the GitHub documentation][git-setup] to guide you through it.
 
-## Config auto-remote
+## Configure auto-remote
 
 When working collaboratively with git, you will need to synchronise your work between your local work area and a remote repository. To remove the need to manually set up the remote connection for each branch, you can set this configuration option:
 

--- a/docs/HowTos/GitAndGitHub/git_setup.md
+++ b/docs/HowTos/GitAndGitHub/git_setup.md
@@ -4,12 +4,7 @@ Make sure you set up git on every machine (including servers such as HPCs for ex
 
 ## Config name and email
 
-All commits on git have information about the author with the name and email address. Before any work with Git, you should configure them globally for each machine you use by typing in a terminal:
-
-```
-$ git config --global user.email "YOUR_EMAIL"
-$ git config --global user.name "YOUR_NAME"
-```
+All commits on git have information about the author with the name and email address. Before any work with Git, you should configure them globally for each machine you use. See [the GitHub documentation][git-setup] to guide you through it.
 
 ## Config auto-remote
 
@@ -18,3 +13,5 @@ When working collaboratively with git, you will need to synchronise your work be
 ```
 $ git config --global --add push.autoSetupRemote true
 ```
+
+[git-setup]: https://docs.github.com/en/get-started/quickstart/set-up-git#setting-up-git

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,4 +71,5 @@ nav:
     - Git and GitHub:
       - HowTos/GitAndGitHub/index.md
       - Basics: HowTos/GitAndGitHub/basics.md
+      - Git setup: HowTos/GitAndGitHub/git_setup.md
       - GitHub setup: HowTos/GitAndGitHub/github_setup.md


### PR DESCRIPTION
People need to configure their name and email before using Git. In addition, this is to recommend setting up the remote automatically for push. This avoids the `push -u` or `push --set-upstream` step, people can then always use `push` without an option.